### PR TITLE
Protect against divide by zero

### DIFF
--- a/Sources/ScrollingTabController.swift
+++ b/Sources/ScrollingTabController.swift
@@ -70,6 +70,10 @@ public class ScrollingTabController: UIViewController, UIScrollViewDelegate, UIC
     
     /// The current scrolled percentage
     var scrolledPercentage: CGFloat {
+        guard tabControllersView.contentSize.width > 0 else {
+            return 0
+        }
+
         return self.tabControllersView.contentOffset.x / tabControllersView.contentSize.width
     }
     
@@ -320,7 +324,11 @@ public class ScrollingTabController: UIViewController, UIScrollViewDelegate, UIC
     }
     
     func checkAndLoadPages() {
-        let width = tabControllersView.frame.size.width
+        let width = tabControllersView.bounds.width
+        guard width > 0 else {
+            return
+        }
+
         let page = Int(tabControllersView.contentOffset.x / width)
         if page != currentPage {
             currentPage = page


### PR DESCRIPTION
There were cases where our frame could be 0 width, which would cause a
divide by zero crash when calculating indexes. Added early guards to the
two places where this division could happen and instead return a 0
index.

Change one of the calculations of width to use bounds vs. the frame