### PR TITLE
Fix initial selected tab appearance.

### DIFF
--- a/Sources/ScrollingTabController.swift
+++ b/Sources/ScrollingTabController.swift
@@ -143,21 +143,25 @@ public class ScrollingTabController: UIViewController, UIScrollViewDelegate, UIC
     override public func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
 
-        childBeginAppearanceTransition(currentPage, isAppearing: true, animated: animated)
-    }
-
-    override public func viewDidAppear(animated: Bool) {
-        super.viewDidAppear(animated)
-        childEndAppearanceTransition(currentPage)
-
         if let selectedPage = deferredInitialSelectedPage where !initialAppearanceComplete {
             initialAppearanceComplete = true
             selectTab(atIndex: selectedPage, animated: false)
             deferredInitialSelectedPage = nil
         } else {
+            childBeginAppearanceTransition(currentPage, isAppearing: true, animated: animated)
             tabView.panToPercentage(scrolledPercentage)
         }
+
         delegate?.scrollingTabController(self, displayedViewControllerAtIndex: currentPage)
+    }
+
+    override public func viewDidAppear(animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if initialAppearanceComplete {
+            childEndAppearanceTransition(currentPage)
+        }
+
         initialAppearanceComplete = true
     }
 


### PR DESCRIPTION
When the view controller specified an initial tab before it was
displayed, that tab was not set before the appearance happened. This
changes the order so that the tab is selected in viewWillAppear to fix
the issue